### PR TITLE
[5주차] 정찬원/[feat] 이메일 로그인 유저 정보 수정

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -57,17 +57,16 @@ Axios.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
     //accessToekn 만료
-    if (error.response?.status === 401 && !originalRequest.retry) {
+    if (error.response?.status === 500 && !originalRequest.retry) {
       originalRequest.retry = true;
 
       try {
-        const { accessToken, refreshToken } = await getRefreshToken();
+        const { accessToken } = await getRefreshToken();
         originalRequest.headers['Authorization'] = `Bearer ${accessToken}`;
-        originalRequest.headers['Authorization_refresh'] = `Bearer ${refreshToken}`;
 
         return Axios(originalRequest);
       } catch (refreshError) {
-        console.error('새로운 엑세스 토큰 발행에 실패했습니다!');
+        console.error('새로운 엑세스 토큰 발행에 실패했습니다!', refreshError);
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
         alert('로그인이 만료되었습니다');

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -57,7 +57,10 @@ Axios.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
     //accessToekn 만료
-    if (error.response?.status === 500 && !originalRequest.retry) {
+    if (
+      (error.response?.status === 500 || error.response?.status === 401) &&
+      !originalRequest.retry
+    ) {
       originalRequest.retry = true;
 
       try {

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-
+//https://blog.leets.land
 const BaseUrl = import.meta.env.VITE_API_URL;
 
 const Axios = axios.create({

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -6,7 +6,8 @@ export const getUserInfo = async () => {
 };
 
 export const updateUserInfo = async (userData) => {
-  const response = await Axios.patch('/users', { userData });
+  console.log('보낼 유저 데이터:', userData);
+  const response = await Axios.patch('/users', userData);
   return response.data;
 };
 

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,0 +1,31 @@
+import { Axios } from './auth';
+
+export const getUserInfo = async () => {
+  const response = await Axios.get('/users/me');
+  return response.data.data; // { id, email, nickname, profilePicture }
+};
+
+export const updateUserInfo = async (userData) => {
+  const { email, name, birthDate, introduction, profilePicture, nickname, password } = userData;
+
+  const response = await Axios.patch('/users', {
+    email,
+    name,
+    birthDate,
+    introduction,
+    profilePicture,
+    nickname,
+    password,
+  });
+  return response.data;
+};
+
+export const updateNickname = async (nickname) => {
+  const response = await Axios.patch('/users/nickname', { nickname });
+  return response.data;
+};
+
+export const updatePassword = async (password) => {
+  const response = await Axios.patch('/users/password', { password });
+  return response.data;
+};

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -6,17 +6,7 @@ export const getUserInfo = async () => {
 };
 
 export const updateUserInfo = async (userData) => {
-  const { email, name, birthDate, introduction, profilePicture, nickname, password } = userData;
-
-  const response = await Axios.patch('/users', {
-    email,
-    name,
-    birthDate,
-    introduction,
-    profilePicture,
-    nickname,
-    password,
-  });
+  const response = await Axios.patch('/users', { userData });
   return response.data;
 };
 

--- a/src/components/Modal/LoginModal.jsx
+++ b/src/components/Modal/LoginModal.jsx
@@ -192,6 +192,9 @@ const LoginModal = ({ isOpen, onClose }) => {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             errorState={errorState} // 상태 전달
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleLogin();
+            }}
           />
           <Button
             width='82%'

--- a/src/components/Modal/LoginModal.jsx
+++ b/src/components/Modal/LoginModal.jsx
@@ -176,28 +176,28 @@ const LoginModal = ({ isOpen, onClose }) => {
           <Text>You can make anything by writing</Text>
         </LeftContent>
         <RightContent>
-          <Input
-            width='80%'
-            height='45px'
-            placeholder='이메일'
-            type='email'
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-          <Input
-            width='80%'
-            height='45px'
-            placeholder='비밀번호'
-            type='password'
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            errorState={errorState} // 상태 전달
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') handleLogin();
-            }}
-          />
+          <div style={{ width: '77%', margin: '0 12px 10px 0' }}>
+            <Input
+              placeholder='이메일'
+              type='email'
+              borderStyle='4px'
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <Input
+              placeholder='비밀번호'
+              type='password'
+              borderStyle='4px'
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              errorState={errorState} // 상태 전달
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleLogin();
+              }}
+            />
+          </div>
           <Button
-            width='82%'
+            width='80%'
             height='48px'
             borderStyle='none'
             color='white'
@@ -209,7 +209,7 @@ const LoginModal = ({ isOpen, onClose }) => {
           </Button>
           <Sns>SNS</Sns>
           <Button
-            width='82%'
+            width='80%'
             height='48px'
             borderStyle='none'
             fontWeight='bold'

--- a/src/components/layout/Header/EditLog.jsx
+++ b/src/components/layout/Header/EditLog.jsx
@@ -20,8 +20,13 @@ const TextButton = styled.button`
   }
 `;
 
-const SetMypage = ({ onToast }) => {
+const SetMypage = ({ onSave, onToast }) => {
   const [isOpen, setOpen] = useState(false);
+
+  const handleSave = () => {
+    if (onSave) onSave();
+    setOpen(false);
+  };
 
   return (
     <Container>
@@ -32,7 +37,14 @@ const SetMypage = ({ onToast }) => {
           <TextButton onClick={() => setOpen(false)} style={{ color: '#FF3F3F' }}>
             취소하기
           </TextButton>
-          <TextButton onClick={onToast}>저장하기</TextButton>
+          <TextButton
+            onClick={() => {
+              onToast?.();
+              handleSave();
+            }}
+          >
+            저장하기
+          </TextButton>
         </>
       )}
     </Container>

--- a/src/components/layout/Header/Header.jsx
+++ b/src/components/layout/Header/Header.jsx
@@ -37,7 +37,7 @@ const SideBarIconClick = styled(SideBarIcon)`
   }
 `;
 
-const Header = ({ onToast }) => {
+const Header = ({ onSave, onToast }) => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isLogoutModal, setIsLogoutModal] = useState(false);
   const [isLoginModal, setIsLoginModal] = useState(false);
@@ -66,7 +66,7 @@ const Header = ({ onToast }) => {
   } else if (isWritePage) {
     headerContent = <DeleteandLog onToast={onToast} />;
   } else if (isMypage || isEditPage) {
-    headerContent = <EditLog onToast={onToast} />;
+    headerContent = <EditLog onSave={onSave} onToast={onToast} />;
   } else if (!isSignupPage) {
     headerContent = <CreateLog />;
   }

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -1,28 +1,32 @@
 import styled from 'styled-components';
 
+const Wrapper = styled.div`
+  width: 100%;
+  height: 60px;
+`;
+
 const StyledInput = styled.input`
-  width: ${(props) => props.width || '500px'};
-  height: ${(props) => props.height || '50px'};
+  width: ${(props) => props.width || '100%'};
+  height: ${(props) => props.height || '45px'};
   font-size: ${(props) => props.fontSize || '16px'};
   font-weight: ${(props) => props.fontWeight || 'normal'};
   color: ${(props) => props.color || 'black'};
   background-color: ${(props) => props.$bgColor || 'white'};
   border: ${(props) => props.$borderStyle || '1px solid #ccc'};
-  border-radius: ${(props) => props.radius || '4px'};
+  border-radius: ${(props) => props.radius || '3px'};
   padding-left: 12px;
 
   &::placeholder {
     color: #bbb;
-    font-size: ${(props) => props.$phSize || '12px'};
+    font-size: ${(props) => props.$phSize || '14px'};
   }
 `;
 
 const ErrorText = styled.p`
-  color: #ff3f3f;
+  color: ${(props) => (props.$showHint ? '#9e9e9e' : '#ff3f3f')};
   font-size: 12px;
   font-weight: 300;
   padding-left: 10px;
-  width: 80%;
   text-align: left;
   margin: 4px 0;
 `;
@@ -45,9 +49,10 @@ const Input = ({
   onKeyDown,
   disabled = false,
   value,
+  showHint,
 }) => {
   return (
-    <>
+    <Wrapper>
       <StyledInput
         width={width}
         height={height}
@@ -66,9 +71,11 @@ const Input = ({
         onKeyDown={onKeyDown}
         disabled={disabled}
         value={value}
+        $showHint={showHint}
       />
+      {showHint && !errorState && <ErrorText $showHint={true}>* 20글자 이내</ErrorText>}
       {errorState && <ErrorText>* {errorState.message}</ErrorText>}
-    </>
+    </Wrapper>
   );
 };
 

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -42,6 +42,7 @@ const Input = ({
   errorState,
   onFocus,
   onChange,
+  onKeyDown,
   disabled = false,
   value,
 }) => {
@@ -62,6 +63,7 @@ const Input = ({
         $errorState={errorState}
         onFocus={onFocus}
         onChange={onChange}
+        onKeyDown={onKeyDown}
         disabled={disabled}
         value={value}
       />

--- a/src/constant/SignupFields.js
+++ b/src/constant/SignupFields.js
@@ -18,13 +18,13 @@ export const createInputFields = (
             label: '비밀번호',
             name: 'password',
             type: 'password',
-            placeholder: '비밀번호',
+            placeholder: '.....',
           },
           {
             label: '비밀번호 확인',
             name: 'confirmPassword',
             type: 'password',
-            placeholder: '비밀번호 확인',
+            placeholder: '.....',
           },
         ]
       : []),

--- a/src/constant/SignupFields.js
+++ b/src/constant/SignupFields.js
@@ -1,23 +1,33 @@
-export const createInputFields = (formData, setFormData, formError) =>
-  [
+export const createInputFields = (
+  formData,
+  setFormData,
+  formError = {},
+  isKakao = false,
+  isUserInfo = false,
+) => {
+  const inputfields = [
     {
       label: '이메일',
       name: 'email',
       type: 'email',
       placeholder: '이메일',
     },
-    {
-      label: '비밀번호',
-      name: 'password',
-      type: 'password',
-      placeholder: '비밀번호',
-    },
-    {
-      label: '비밀번호 확인',
-      name: 'confirmPassword',
-      type: 'password',
-      placeholder: '비밀번호 확인',
-    },
+    ...(!isKakao
+      ? [
+          {
+            label: '비밀번호',
+            name: 'password',
+            type: 'password',
+            placeholder: '비밀번호',
+          },
+          {
+            label: '비밀번호 확인',
+            name: 'confirmPassword',
+            type: 'password',
+            placeholder: '비밀번호 확인',
+          },
+        ]
+      : []),
     {
       label: '이름',
       name: 'name',
@@ -42,9 +52,16 @@ export const createInputFields = (formData, setFormData, formError) =>
       type: 'text',
       placeholder: '한 줄 소개',
     },
-  ].map((field) => ({
+  ];
+
+  const mypageFields = isUserInfo
+    ? inputfields.filter((field) => field.name !== 'nickname' && field.name !== 'bio')
+    : inputfields;
+
+  return mypageFields.map((field) => ({
     ...field,
     value: formData[field.name],
     onChange: (e) => setFormData((prev) => ({ ...prev, [field.name]: e.target.value })),
     error: formError[field.name],
   }));
+};

--- a/src/data/userDummy.js
+++ b/src/data/userDummy.js
@@ -1,0 +1,7 @@
+const userDummy = {
+  name: '정찬원',
+  birthDate: '2001-05-22',
+  introduction: '하이',
+};
+
+export default userDummy;

--- a/src/pages/KakaoRedirectPage.jsx
+++ b/src/pages/KakaoRedirectPage.jsx
@@ -26,7 +26,8 @@ const KakaoRedirectPage = () => {
           console.log('카카오 로그인 성공', Auth);
           storeTokens(Auth.data.accessToken, Auth.data.refreshToken);
         } else if (Auth?.code === 401) {
-          navigate('/signup/Kakao');
+          const { kakaoId, nickname, picture } = Auth.data;
+          navigate('/signup/Kakao', { state: { kakaoId, nickname, picture } });
         }
       } catch (error) {
         console.error('카카오 로그인 실패:', error);

--- a/src/pages/MyBlog.jsx
+++ b/src/pages/MyBlog.jsx
@@ -10,10 +10,10 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   background-color: #f5f5f5;
-  height: 390px;
+  height: 400px;
 
   @media (max-width: 700px) {
-    height: 370px;
+    height: 380px;
   }
 `;
 
@@ -61,7 +61,7 @@ const BioText = styled.p`
 
 const Content = styled.div`
   min-width: 700px;
-  margin: 50px auto;
+  margin: 60px auto;
 
   @media (max-width: 700px) {
     min-width: 400px;

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -4,6 +4,7 @@ import { Header, Image, Input } from '@/components';
 import { Profile } from '@/assets';
 import GlobalStyle from '@/styles/global';
 import SetMypage from '@/components/layout/Header/EditLog';
+import { createInputFields } from '@/constant/SignupFields';
 
 const Container = styled.div`
   position: relative;
@@ -37,66 +38,28 @@ const Content = styled.div`
 const ProfileContent = styled.div`
   display: flex;
   flex-direction: column;
-  min-width: 600px;
-  padding-top: 100px;
-  gap: 20px;
-
-  @media (max-width: 700px) {
-    min-width: 440px;
-    padding-top: 80px;
-  }
-`;
-
-const InputContent = styled.div`
-  display: flex;
-  flex-direction: column;
-  padding-top: 15px;
-  margin-bottom: 40px;
+  margin: 85px 0 40px 0;
   gap: 40px;
 `;
 
-const Styledgap = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 15px;
-`;
-
-const Text = styled.div`
+export const Text = styled.div`
   color: #9e9e9e;
   font-size: 14px;
-  margin-top: 20px;
-  margin-left: 7px;
+  margin: 15px 0 13px 7px;
 `;
 
 const Mypage = () => {
-  const [userInfo, setUserInfo] = useState({
-    nickname: '',
-    bio: '',
+  const [formData, setFormData] = useState({
     email: '',
     password: '',
+    confirmPassword: '',
     name: '',
     birth: '',
+    nickname: '',
+    bio: '',
   });
 
-  useEffect(() => {
-    const storedUser = JSON.parse(localStorage.getItem('userInfo'));
-    if (storedUser) {
-      setUserInfo(storedUser);
-    }
-  }, []);
-
-  const inputFields = [
-    { label: '이메일', value: userInfo?.email || '', placeholder: '이메일' },
-    { label: '비밀번호', value: userInfo?.password || '', placeholder: '......', type: 'password' },
-    {
-      label: '비밀번호 확인',
-      value: userInfo?.password || '',
-      placeholder: '......',
-      type: 'password',
-    },
-    { label: '이름', value: userInfo?.name || '', placeholder: '이름' },
-    { label: '생년월일', value: userInfo?.birth || '', placeholder: 'YYYY-MM-DD' },
-  ];
+  const inputFields = createInputFields(formData, setFormData, {}, false, true);
 
   return (
     <>
@@ -106,84 +69,37 @@ const Mypage = () => {
         <Content>
           <ProfileContent>
             <Image src={Profile} alt='프로필' width='64px' height='64px' radius='50%' />
-            <InputContent>
+            {['nickname', 'bio'].map((field) => (
               <Input
+                key={field}
                 width='100%'
-                height='60px'
-                fontSize='24px'
+                height={field === 'nickname' ? '60px' : '45px'}
+                fontSize={field === 'nickname' ? '24px' : undefined}
                 radius='3px'
-                placeholder='닉네임'
-                phSize='24px'
+                placeholder={field === 'nickname' ? '닉네임' : '한 줄 소개'}
+                phSize={field === 'nickname' ? '24px' : '14px'}
                 bgColor='#f5f5f5'
-                value={userInfo?.nickname || ''}
-                disabled
+                value={formData[field] || ''}
+                onChange={(e) => setFormData((prev) => ({ ...prev, [field]: e.target.value }))}
               />
+            ))}
+          </ProfileContent>
+          {inputFields.map((field) => (
+            <div key={field.name}>
+              <Text>{field.label}</Text>
               <Input
                 width='100%'
                 height='45px'
                 radius='3px'
-                placeholder='한 줄 소개'
                 phSize='14px'
-                bgColor='#f5f5f5'
-                value={userInfo?.bio || ''}
-                disabled
+                placeholder={field.placeholder}
+                type={field.type}
+                name={field.name}
+                value={field.value}
+                onChange={field.onChange}
               />
-            </InputContent>
-          </ProfileContent>
-          <Styledgap>
-            <Text>이메일</Text>
-            <Input
-              width='100%'
-              height='45px'
-              radius='3px'
-              placeholder='이메일'
-              phSize='14px'
-              value={userInfo?.email || ''}
-              disabled
-            />
-            <Text>비밀번호</Text>
-            <Input
-              width='100%'
-              height='45px'
-              radius='3px'
-              placeholder='......'
-              phSize='14px'
-              value={userInfo?.password || ''}
-              type='password'
-              disabled
-            />
-            <Text>비밀번호 확인</Text>
-            <Input
-              width='100%'
-              height='45px'
-              radius='3px'
-              placeholder='......'
-              phSize='14px'
-              value={userInfo?.password || ''}
-              type='password'
-              disabled
-            />
-            <Text>이름</Text>
-            <Input
-              width='100%'
-              height='45px'
-              radius='3px'
-              placeholder='이름'
-              phSize='14px'
-              value={userInfo?.name || ''}
-              disabled
-            />
-            <Text>생년월일</Text>
-            <Input
-              width='100%'
-              height='45px'
-              radius='3px'
-              placeholder='YYYY-MM-DD'
-              phSize='14px'
-              value={userInfo?.birth || ''}
-              disabled
-            />
-          </Styledgap>
+            </div>
+          ))}
         </Content>
       </Container>
     </>

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -45,6 +45,33 @@ const ProfileContent = styled.div`
   gap: 40px;
 `;
 
+const ImageWrapper = styled.div`
+  position: relative;
+  width: 64px;
+  height: 64px;
+`;
+
+const EditButton = styled.button`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background-color: #464646;
+  border: 2px solid white;
+  color: white;
+  font-size: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(0.9);
+  }
+`;
+
 export const Text = styled.div`
   color: #9e9e9e;
   font-size: 14px;
@@ -136,7 +163,10 @@ const Mypage = () => {
         <Header onSave={handleSave} />
         <Content>
           <ProfileContent>
-            <Image src={Profile} alt='프로필' width='64px' height='64px' radius='50%' />
+            <ImageWrapper>
+              <Image src={Profile} alt='프로필' width='64px' height='64px' radius='50%' />
+              <EditButton onClick={() => alert('프로필 수정 클릭')}>+</EditButton>
+            </ImageWrapper>
             {['nickname', 'bio'].map((field) => (
               <Input
                 key={field}

--- a/src/pages/SignUp/SignUpEmail.jsx
+++ b/src/pages/SignUp/SignUpEmail.jsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { EmailSignUp } from '@/api/SignUp';
 import { useMutation } from '@tanstack/react-query';
 import { createInputFields } from '@/constant/SignupFields';
-import { onValiadation } from '@/utils/validation';
+import { onValidation } from '@/utils/validation';
 import { Container, Content, Text } from '@/styles/SignupStyles';
 
 const SignUpEmail = () => {
@@ -42,7 +42,7 @@ const SignUpEmail = () => {
       }),
     onSuccess: (data) => {
       if (data.error) {
-        onValiadation(formData, setFormError, data.message); // 사용 중인 이메일, 닉네임 여부 확인
+        onValidation(formData, setFormError, data.message); // 사용 중인 이메일, 닉네임 여부 확인
         console.log(data.message);
       } else {
         setModalOpen(true);
@@ -54,7 +54,7 @@ const SignUpEmail = () => {
   });
 
   const handleSignUp = () => {
-    const isValid = onValiadation(formData, setFormError); //먼저 실행
+    const isValid = onValidation(formData, setFormError); //먼저 실행
     if (isValid) {
       signupMutation.mutate();
     }
@@ -84,11 +84,7 @@ const SignUpEmail = () => {
             <div key={field.name}>
               <Text>{field.label}</Text>
               <Input
-                width='100%'
-                height='45px'
-                radius='3px'
                 placeholder={field.placeholder}
-                phSize='14px'
                 value={field.value}
                 onChange={field.onChange}
                 name={field.name}

--- a/src/pages/SignUp/SignUpKakao.jsx
+++ b/src/pages/SignUp/SignUpKakao.jsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { KakaoSignUp } from '@/api/SignUp';
 import { useMutation } from '@tanstack/react-query';
 import { createInputFields } from '@/constant/SignupFields';
-import { onValiadation } from '@/utils/validation';
+import { onValidation } from '@/utils/validation';
 import { Container, Content, Text, SocialBox } from '@/styles/SignupStyles';
 
 const SignUpKakao = () => {
@@ -41,7 +41,7 @@ const SignUpKakao = () => {
       }),
     onSuccess: (data) => {
       if (data.error) {
-        onValiadation(formData, setFormError, data.message);
+        onValidation(formData, setFormError, data.message);
         console.log(data.message);
       } else {
         setModalOpen(true);
@@ -53,7 +53,7 @@ const SignUpKakao = () => {
   });
 
   const handleSignUp = () => {
-    const isValid = onValiadation(formData, setFormError); //먼저 실행
+    const isValid = onValidation(formData, setFormError); //먼저 실행
     if (isValid) {
       signupMutation.mutate();
     }
@@ -88,10 +88,6 @@ const SignUpKakao = () => {
             <div key={field.name}>
               <Text>{field.label}</Text>
               <Input
-                width='100%'
-                height='45px'
-                radius='3px'
-                phSize='14px'
                 placeholder={field.placeholder}
                 type={field.type}
                 name={field.name}

--- a/src/pages/SignUp/SignUpKakao.jsx
+++ b/src/pages/SignUp/SignUpKakao.jsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Header, Image, Button, Input, Modal, SignUpHeader } from '@/components';
-import { AddPhoto, Profile, KakaoIcon } from '@/assets';
+import { AddPhoto, KakaoIcon } from '@/assets';
 import GlobalStyle from '@/styles/global';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { KakaoSignUp } from '@/api/SignUp';
 import { useMutation } from '@tanstack/react-query';
 import { createInputFields } from '@/constant/SignupFields';
@@ -11,11 +11,11 @@ import { Container, Content, Text, SocialBox } from '@/styles/SignupStyles';
 
 const SignUpKakao = () => {
   const [modalOpen, setModalOpen] = useState(false);
+  const location = useLocation();
+  const { kakaoId, nickname, picture } = location.state || {};
   const [formData, setFormData] = useState({
     email: '',
-    password: '',
-    confirmPassword: '',
-    name: '',
+    name: nickname || '',
     birth: '',
     nickname: '',
     bio: '',
@@ -34,14 +34,15 @@ const SignUpKakao = () => {
       KakaoSignUp({
         email: formData.email,
         nickname: formData.nickname,
-        profilePicture: '',
+        profilePicture: picture || '',
         birthDate: formData.birth,
         name: formData.name,
         introduction: formData.bio,
+        kakaoId: kakaoId,
       }),
     onSuccess: (data) => {
       if (data.error) {
-        onValidation(formData, setFormError, data.message);
+        onValidation(formData, setFormError, data.message, false, true);
         console.log(data.message);
       } else {
         setModalOpen(true);
@@ -53,7 +54,7 @@ const SignUpKakao = () => {
   });
 
   const handleSignUp = () => {
-    const isValid = onValidation(formData, setFormError); //먼저 실행
+    const isValid = onValidation(formData, setFormError, '', false, true); //먼저 실행
     if (isValid) {
       signupMutation.mutate();
     }
@@ -68,7 +69,7 @@ const SignUpKakao = () => {
         <SignUpHeader />
         <Content>
           <Text>프로필 사진</Text>
-          <Image src={Profile} alt='프로필' width='90px' height='90px' radius='50%' />
+          <Image src={picture} alt='프로필' width='90px' height='90px' radius='50%' />
           <Button
             width='145px'
             height='27px'

--- a/src/pages/SignUp/SignUpKakao.jsx
+++ b/src/pages/SignUp/SignUpKakao.jsx
@@ -59,7 +59,7 @@ const SignUpKakao = () => {
     }
   };
 
-  const inputFields = createInputFields(formData, setFormData, formError);
+  const inputFields = createInputFields(formData, setFormData, formError, true);
   return (
     <>
       <GlobalStyle />

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 
-export const onValiadation = (formData, setFormError, msg = '') => {
+export const onValidation = (formData, setFormError, msg = '', myPageCheck) => {
   const errors = {};
   const todayString = dayjs().format('YYYY년 M월 D일');
   const today = dayjs();
@@ -28,6 +28,18 @@ export const onValiadation = (formData, setFormError, msg = '') => {
       };
     }
   });
+
+  if (myPageCheck) {
+    const isSameEmail = formData.email === myPageCheck.email;
+    const isSameNickname = formData.nickname === myPageCheck.nickname;
+
+    if (isSameEmail && isSameNickname) {
+      errors.email = { message: '이전과 동일한 이메일입니다.' };
+      errors.nickname = { message: '이전과 동일한 닉네임입니다.' };
+    } else if (isSameNickname) {
+      errors.nickname = { message: '이전과 동일한 닉네임입니다.' };
+    }
+  }
 
   if (email && email.trim() && !emailRegex.test(email)) {
     errors.email = { message: '이메일 형식이 올바르지 않습니다.' };

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 
-export const onValidation = (formData, setFormError, msg = '', myPageCheck) => {
+export const onValidation = (formData, setFormError, msg = '', myPageCheck, isKakao = false) => {
   const errors = {};
   const todayString = dayjs().format('YYYY년 M월 D일');
   const today = dayjs();
@@ -20,8 +20,12 @@ export const onValidation = (formData, setFormError, msg = '', myPageCheck) => {
     nickname: '닉네임',
   };
 
+  const fieldsCheck = isKakao
+    ? Object.keys(formDataFields).filter((field) => field !== 'password')
+    : Object.keys(formDataFields);
+
   //formDataFieldsr객체를 배열로 만듦 -> forEach로 순서대로 값을 가져옴
-  Object.keys(formDataFields).forEach((field) => {
+  fieldsCheck.forEach((field) => {
     if (!formData[field]?.trim()) {
       errors[field] = {
         message: `${formDataFields[field]}는 반드시 입력해야하는 필수 사항입니다.`,
@@ -47,11 +51,13 @@ export const onValidation = (formData, setFormError, msg = '', myPageCheck) => {
     errors.email = { message: '이미 사용중인 이메일입니다.' };
   }
 
-  if (password && password.trim()) {
-    if (password.length < 8 || password.length > 64) {
-      errors.password = { message: '비밀번호는 최소 8자 이상, 최대 64자 이하여야 합니다.' };
-    } else if (!passwordRegex.test(password)) {
-      errors.password = { message: '비밀번호 8~64자, 영문, 숫자, 특수문자가 필수입니다.' };
+  if (!isKakao) {
+    if (password && password.trim()) {
+      if (password.length < 8 || password.length > 64) {
+        errors.password = { message: '비밀번호는 최소 8자 이상, 최대 64자 이하여야 합니다.' };
+      } else if (!passwordRegex.test(password)) {
+        errors.password = { message: '비밀번호 8~64자, 영문, 숫자, 특수문자가 필수입니다.' };
+      }
     }
   }
 


### PR DESCRIPTION
## 1. 업데이트 사항

- 이메일 로그인 유저 정보 수정 구현 
- accessToken 재발급 코드 수정

<br>

## 2. 어떤 위험이나 장애를 발견했나요?
1. 닉네임과 비밀번호가 수정된 후 전체 수정에도 중복으로 들어가서 409에러인
"이미 사용중인 닉네임입니다."가 계속 뜨고 있는 상황 (해결 완료)
![화면 캡처 2025-05-06 232939](https://github.com/user-attachments/assets/6260a7f3-1582-4c61-a210-0513fc0a38ef)


2. /users/me에서 유저 정보를 가져올 때 id, email, nickname, profiePicture 이렇게만 응답으로 오는데 그러면 소개, 생년월일, 이름 등은 어디서 가져와야 하는지 모르겠습니다.. 

<br>

## 3. 관련 스크린샷을 첨부해주세요.
![화면 캡처 2025-05-06 231754](https://github.com/user-attachments/assets/e19f3a47-7a06-4665-9a2b-a4aaa5c33f74)


<br>

## 4. 완료 사항
- 이메일 로그인 유저 정보 수정 구현
- 카카오 로그인/회원가입 API 구현 완료

## 5. 추가사항
카카오 API 구현할 때 좀 많이 헤매서 다른 것들 구현하기엔 시간이 부족했던거 같습니다. 다음 주차까지 남은 API 구현 해보겠습니다

closed #49 