### PR TITLE
[5주차] 서나영/[feat] 게시글 CRUD 구현

### DIFF
--- a/서나영-Blog/src/App.tsx
+++ b/서나영-Blog/src/App.tsx
@@ -18,6 +18,7 @@ function App() {
         <Routes>
           <Route path='/' element={<Home />} />
           <Route path='/blog/editor' element={<BlogEditor />} />
+          <Route path='/blog/editor/:postId' element={<BlogEditor />} />
           <Route path='/blog/:postId' element={<BlogDetail />} />
           <Route path='/signup' element={<Signup />} />
           <Route path='/signup/select' element={<SignupSelect />} />

--- a/서나영-Blog/src/api/blog/postAPI.ts
+++ b/서나영-Blog/src/api/blog/postAPI.ts
@@ -1,0 +1,24 @@
+import api from '@/api/api';
+import { BlogPost } from '@/types/blogPost';
+
+// 토큰 없는 게시글 리스트 조회
+export const getPostList = async (page: number, size: number) => {
+  console.log('게시물 리스트 요청 params:', { page, size });
+
+  const response = await api.get<{ code: number; message: string; data: BlogPost[] }>(
+    `/posts/all`,
+    { params: { page, size } },
+  );
+  console.log('게시글 리스트 조회: ', response.data);
+  return response.data.data;
+};
+
+// 토큰 있는 게시글 리스트 조회
+export const getPostListWithToken = async (page: number, size: number) => {
+  const response = await api.get<{ code: number; message: string; data: BlogPost[] }>(
+    `/posts/all/token`,
+    { params: { page, size } },
+  );
+  console.log('게시글 리스트 조회: ', response.data);
+  return response.data.data;
+};

--- a/서나영-Blog/src/api/blog/postDetailAPI.ts
+++ b/서나영-Blog/src/api/blog/postDetailAPI.ts
@@ -1,0 +1,66 @@
+import api from '@/api/api';
+import { BlogPostDetail, BlogPostContent } from '@/types/blogPost';
+
+// 게시글 작성
+export const createPost = async (title: string, contents: BlogPostContent[]) => {
+  const response = await api.post('/posts', { title, contents });
+  console.log('게시글 작성: ', response.data);
+  return response.data;
+};
+
+// 게시글 조회
+export const getPostDetail = async (postId: string) => {
+  try {
+    const response = await api.get<{
+      code: number;
+      message: string;
+      data: BlogPostDetail;
+    }>('/posts', {
+      params: { postId },
+    });
+
+    return response.data.data;
+  } catch (error) {
+    console.error('게시글 상세 조회 실패:', error);
+    throw error;
+  }
+};
+
+// 게시글 삭제
+export const deletePost = async (postId: string) => {
+  try {
+    const response = await api.delete('/posts', {
+      params: { postId },
+    });
+    console.log('게시글 삭제 요청: ', response.data);
+    return response;
+  } catch (error) {
+    console.error('게시글 삭제 실패:', error);
+    throw error;
+  }
+};
+
+// 게시글 업데이트
+export const updatePost = async (
+  postId: string,
+  updateData: {
+    title: string;
+    contents: {
+      contentOrder: number;
+      content: string;
+      contentType: 'TEXT' | 'IMAGE';
+    }[];
+  },
+) => {
+  try {
+    const response = await api.patch('/posts', updateData, {
+      params: { postId },
+    });
+
+    console.log('게시글 수정 성공:', response.data);
+    return response.data;
+  } catch (error) {
+    console.error('게시글 수정 실패:', error);
+    throw error;
+  }
+};

--- a/서나영-Blog/src/components/blog/BlogMeta.tsx
+++ b/서나영-Blog/src/components/blog/BlogMeta.tsx
@@ -41,23 +41,37 @@ const StyledCommentCount = styled.span`
   font-weight: 300;
 `;
 
-interface PostMetaProps {
-  post: BlogPost;
+interface BlogPostWithOptionalDetail extends BlogPost {
+  createdAt?: string;
+  comments?: Comment[];
+  nickName?: string;
+  profileUrl?: string;
 }
 
-const BlogMeta: React.FC<PostMetaProps> = ({ post }) => {
+interface PostMetaProps {
+  post: BlogPostWithOptionalDetail;
+  isBlogDetail?: boolean;
+}
+
+const BlogMeta: React.FC<PostMetaProps> = ({ post, isBlogDetail = false }) => {
+  const profilePicture = isBlogDetail && post.profileUrl ? post.profileUrl : '';
+  const nickName = isBlogDetail && post.nickName ? post.nickName : '닉네임';
+  const createdAt = isBlogDetail && post.createdAt ? post.createdAt : '';
+
   return (
     <MetaContainer>
-      {post.profileUrl ? (
-        <ProfileImage src={post.profileUrl} alt='profile' />
+      {profilePicture ? (
+        <ProfileImage src={profilePicture} alt='profile' />
       ) : (
         <Profile width={20} height={20} />
       )}
-      <StyledNickName>{post.nickName}</StyledNickName>
+      <StyledNickName>{nickName}</StyledNickName>
       <Dot />
-      <StyledCreatedAt>{formatPostDate(post.createdAt)}</StyledCreatedAt>
+      <StyledCreatedAt>{formatPostDate(createdAt)}</StyledCreatedAt>
       <Dot />
-      <StyledCommentCount>댓글 {post.comments.length}</StyledCommentCount>
+      <StyledCommentCount>
+        댓글 {isBlogDetail ? (post.comments?.length ?? 0) : (post.commentCount ?? 0)}
+      </StyledCommentCount>
     </MetaContainer>
   );
 };

--- a/서나영-Blog/src/components/blog/blogDetail/BlogTitle.tsx
+++ b/서나영-Blog/src/components/blog/blogDetail/BlogTitle.tsx
@@ -33,7 +33,7 @@ const BlogTitle: React.FC<BlogTitleProps> = ({ post }) => {
     <BlogTitleContainer>
       <TextWrapper>
         <TitleText>{post.title}</TitleText>
-        <BlogMeta post={post} />
+        <BlogMeta post={post} isBlogDetail={true} />
       </TextWrapper>
     </BlogTitleContainer>
   );

--- a/서나영-Blog/src/components/blog/blogDetail/InfoFooter.tsx
+++ b/서나영-Blog/src/components/blog/blogDetail/InfoFooter.tsx
@@ -27,13 +27,14 @@ const ProfileImage = styled.img`
   height: 64px;
   border-radius: 50%;
   object-fit: cover;
+  padding: 0 16px;
 `;
 
 const NickName = styled.div`
   color: #000;
   font-size: 32px;
   font-weight: 500;
-  padding-top: 24px;
+  padding: 24px 16px 0 16px;
 `;
 
 const Description = styled.div`
@@ -42,23 +43,28 @@ const Description = styled.div`
   font-size: 14px;
   font-weight: 300;
   letter-spacing: -0.07px;
+  padding: 12px 16px;
 `;
 
 interface InfoFooterProps {
   post: BlogPost;
 }
 
-const InfoFooter: React.FC<InfoFooterProps> = ({ post }) => {
+const InfoFooter: React.FC<InfoFooterProps> = () => {
+  const profilePicture = localStorage.getItem('profilePicture') || '';
+  const nickname = localStorage.getItem('nickname') || '닉네임';
+  const introduction = localStorage.getItem('introduction') || 'You can make anything by writing';
+
   return (
     <InfoFooterWrapper>
       <ContentWrapper>
-        {post.profileUrl ? (
-          <ProfileImage src={post.profileUrl} alt='프로필 이미지' />
+        {profilePicture ? (
+          <ProfileImage src={profilePicture} alt='프로필 이미지' />
         ) : (
           <Profile width={60} height={60} />
         )}
-        <NickName>{post.nickName}</NickName>
-        <Description>한 줄 소개</Description>
+        <NickName>{nickname}</NickName>
+        <Description>{introduction}</Description>
       </ContentWrapper>
     </InfoFooterWrapper>
   );

--- a/서나영-Blog/src/components/blog/blogDetail/comment/Comment.tsx
+++ b/서나영-Blog/src/components/blog/blogDetail/comment/Comment.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import CommentMeta from '@/components/blog/blogDetail/comment/CommentMeta';
-import { BlogPost, BlogComment } from '@/types/blogPost';
+import { BlogPostDetail, BlogComment } from '@/types/blogPost';
 
 const CommentWrapper = styled.div`
   display: flex;
@@ -21,7 +21,7 @@ const CommentText = styled.span`
 `;
 
 interface CommentProps {
-  post: BlogPost;
+  post: BlogPostDetail;
   comment: BlogComment;
 }
 

--- a/서나영-Blog/src/components/blog/blogDetail/comment/CommentInput.tsx
+++ b/서나영-Blog/src/components/blog/blogDetail/comment/CommentInput.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import styled from 'styled-components';
 import CommentMeta from './CommentMeta';
 import Button from '@/components/ui/Button';
-import { BlogPost } from '@/types/blogPost';
+import { BlogPostDetail } from '@/types/blogPost';
 
 const CommentInputWrapper = styled.div`
   padding: 12px 16px;
@@ -72,7 +72,7 @@ const LoginMessage = styled.span`
 `;
 
 interface CommentInputProps {
-  post: BlogPost;
+  post: BlogPostDetail;
   placeholder?: string;
   isLogin: boolean;
 }

--- a/서나영-Blog/src/components/blog/blogDetail/comment/CommentList.tsx
+++ b/서나영-Blog/src/components/blog/blogDetail/comment/CommentList.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import Comment from '@/components/blog/blogDetail/comment/Comment';
-import { BlogPost } from '@/types/blogPost';
+import { BlogPostDetail } from '@/types/blogPost';
 import CommentInput from '@/components/blog/blogDetail/comment/CommentInput';
 
 const CommentListContainer = styled.div`
@@ -52,7 +52,7 @@ const NoCommentText = styled.span`
 `;
 
 interface CommentListProps {
-  post: BlogPost;
+  post: BlogPostDetail;
 }
 
 const CommentList: React.FC<CommentListProps> = ({ post }) => {

--- a/서나영-Blog/src/components/blog/blogDetail/comment/CommentMeta.tsx
+++ b/서나영-Blog/src/components/blog/blogDetail/comment/CommentMeta.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { useState } from 'react';
-import { BlogPost } from '@/types/blogPost';
+import { BlogPostDetail } from '@/types/blogPost';
 import { formatPostDate } from '@/utils/date';
 import { MoreVert, Profile } from '@/assets';
 import Modal from '@/components/ui/Modal';
@@ -56,7 +56,7 @@ const IconWrapper = styled.div`
 `;
 
 interface CommentMetaProps {
-  post: BlogPost;
+  post: BlogPostDetail;
   isInput?: boolean;
 }
 

--- a/서나영-Blog/src/components/editor/ContentEditor.tsx
+++ b/서나영-Blog/src/components/editor/ContentEditor.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
+import Image from '@/components/ui/Image';
+import { Block } from '@/types/blogPost';
 
 const EditorContainer = styled.div`
   width: 100%;
@@ -10,9 +12,10 @@ const EditorContainer = styled.div`
 `;
 
 const EditableArea = styled.div<{ $isEmpty: boolean }>`
-  min-height: 400px;
+  min-height: ${({ $isEmpty }) => ($isEmpty ? '150px' : 'auto')};
   padding: 16px;
   font-size: 14px;
+  font-family: 'Noto Sans L';
   line-height: 1.6;
   outline: none;
   white-space: pre-wrap;
@@ -29,44 +32,115 @@ const EditableArea = styled.div<{ $isEmpty: boolean }>`
 `;
 
 interface ContentEditorProps {
-  onChange?: (value: string) => void;
+  onChange: (plainText: string, blocks: Block[]) => void;
+  imageToInsert?: string | null;
+  onImageInsertHandled?: () => void;
+  initialBlocks?: Block[];
 }
 
-const ContentEditor = ({ onChange }: ContentEditorProps) => {
-  const editorRef = useRef<HTMLDivElement>(null);
-  const [isEmpty, setIsEmpty] = useState(true);
+const ContentEditor = ({
+  onChange,
+  imageToInsert,
+  onImageInsertHandled,
+  initialBlocks,
+}: ContentEditorProps) => {
+  const [blocks, setBlocks] = useState<Block[]>([
+    { type: 'TEXT', content: '' }, // 기본 텍스트 블록 하나
+  ]);
 
-  const updateIsEmpty = () => {
-    const text = editorRef.current?.innerText || '';
-    setIsEmpty(text.trim() === '');
-    onChange?.(text);
+  const textRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  // 최초 렌더링 시 초기 블록 세팅
+  useEffect(() => {
+    if (initialBlocks && initialBlocks.length > 0) {
+      setBlocks(initialBlocks);
+    }
+  }, [initialBlocks]);
+
+  // 이미지 URL이 전달되면 blocks에 추가
+  useEffect(() => {
+    if (imageToInsert) {
+      setBlocks((prev) => [
+        ...prev,
+        { type: 'IMAGE', content: imageToInsert },
+        { type: 'TEXT', content: '' },
+      ]);
+      // 이미지 삽입 후 알림
+      onImageInsertHandled?.();
+    }
+  }, [imageToInsert]);
+
+  // blocks 변경 시 plain text 추출 및 전달
+  useEffect(() => {
+    const plainText = blocks
+      .filter((b) => b.type === 'TEXT')
+      .map((b) => b.content)
+      .join('\n\n');
+    onChange(plainText, blocks);
+  }, [blocks]);
+
+  // text 수정 핸들링
+  const handleTextInput = (index: number, e: React.FormEvent<HTMLDivElement>) => {
+    const updatedText = e.currentTarget.innerText;
+    setBlocks((prevBlocks) =>
+      prevBlocks.map((block, i) =>
+        i === index && block.type === 'TEXT' ? { ...block, content: updatedText } : block,
+      ),
+    );
   };
+
+  // text 붙여넣기 핸들링
+  const handlePaste = (index: number, e: React.ClipboardEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const pastedText = e.clipboardData.getData('text/plain');
+
+    document.execCommand('insertText', false, pastedText);
+
+    setTimeout(() => {
+      const div = textRefs.current[index];
+      if (div) {
+        const updatedText = div.innerText;
+        setBlocks((prevBlocks) =>
+          prevBlocks.map((block, i) =>
+            i === index && block.type === 'TEXT' ? { ...block, content: updatedText } : block,
+          ),
+        );
+      }
+    }, 0);
+  };
+
+  // 텍스트 초기 렌더 시 내부 내용만 DOM으로 채움 (커서 꼬임 방지)
+  useEffect(() => {
+    blocks.forEach((block, index) => {
+      const div = textRefs.current[index];
+      if (block.type === 'TEXT' && div && div.innerText !== block.content) {
+        div.innerText = block.content;
+      }
+    });
+  }, [blocks]);
 
   return (
     <EditorContainer>
-      <EditableArea
-        contentEditable
-        ref={editorRef}
-        data-placeholder='어떠한 것을 깨달았나요?'
-        $isEmpty={isEmpty}
-        onInput={updateIsEmpty}
-        // 텍스트 붙여넣기
-        onPaste={(e) => {
-          e.preventDefault();
-          const text = e.clipboardData.getData('text/plain');
-
-          // 현재 커서 위치
-          const selection = window.getSelection();
-          if (!selection?.rangeCount) return;
-
-          selection.deleteFromDocument();
-          selection.getRangeAt(0).insertNode(document.createTextNode(text));
-
-          // 커서를 텍스트 뒤로 이동
-          selection.collapseToEnd();
-          updateIsEmpty();
-        }}
-      />
+      {blocks.map((block, index) =>
+        block.type === 'TEXT' ? (
+          <EditableArea
+            key={index}
+            ref={(el) => {
+              textRefs.current[index] = el;
+            }}
+            contentEditable
+            suppressContentEditableWarning
+            data-placeholder={index === 0 ? '어떠한 것을 깨달았나요?' : ''}
+            onInput={(e) => handleTextInput(index, e)}
+            onPaste={(e) => handlePaste(index, e)}
+            $isEmpty={!block.content}
+          />
+        ) : (
+          <div key={index} style={{ margin: '24px 0' }}>
+            <Image src={block.content} alt={`uploaded-${index}`} />
+          </div>
+        ),
+      )}
     </EditorContainer>
   );
 };

--- a/서나영-Blog/src/components/editor/ImageUpload.tsx
+++ b/서나영-Blog/src/components/editor/ImageUpload.tsx
@@ -5,7 +5,7 @@ import Button from '@/components/ui/Button';
 const ImageUploadWrapper = styled.div`
   display: flex;
   position: fixed;
-  top: 100px;
+  top: 72px;
   left: 50%;
   transform: translateX(-50%);
   width: 100%;
@@ -36,15 +36,15 @@ const HiddenInput = styled.input`
 `;
 
 interface ImageUploadProps {
-  onAddImage: (imageUrl: string) => void;
+  onAddImage: (file: File) => void;
 }
 
 const ImageUpload = ({ onAddImage }: ImageUploadProps) => {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
+    console.log('파일 선택됨:', file);
     if (file) {
-      const url = URL.createObjectURL(file);
-      onAddImage(url);
+      onAddImage(file);
     }
   };
 
@@ -56,7 +56,7 @@ const ImageUpload = ({ onAddImage }: ImageUploadProps) => {
           사진 추가하기
         </StyledButton>
       </label>
-      <HiddenInput type='file' id='imageUpload' accept='image/*' onChange={handleFileChange} />
+      <HiddenInput type='file' id='imageUpload' onChange={handleFileChange} />
     </ImageUploadWrapper>
   );
 };

--- a/서나영-Blog/src/components/editor/ImageUpload.tsx
+++ b/서나영-Blog/src/components/editor/ImageUpload.tsx
@@ -42,7 +42,6 @@ interface ImageUploadProps {
 const ImageUpload = ({ onAddImage }: ImageUploadProps) => {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    console.log('파일 선택됨:', file);
     if (file) {
       onAddImage(file);
     }
@@ -56,7 +55,7 @@ const ImageUpload = ({ onAddImage }: ImageUploadProps) => {
           사진 추가하기
         </StyledButton>
       </label>
-      <HiddenInput type='file' id='imageUpload' onChange={handleFileChange} />
+      <HiddenInput type='file' id='imageUpload' accept='image/*' onChange={handleFileChange} />
     </ImageUploadWrapper>
   );
 };

--- a/서나영-Blog/src/components/layout/header/ChatandMore.tsx
+++ b/서나영-Blog/src/components/layout/header/ChatandMore.tsx
@@ -1,14 +1,19 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
 import { Chat, MoreVert } from '@/assets';
 import styled from 'styled-components';
 import Modal from '@/components/ui/Modal';
 import useDropdown from '@/hooks/useDropdown';
 import Dropdown from '@/components/ui/Dropdown';
 import { useToast } from '@/components/ui/Toast';
+import { deletePost } from '@/api/blog/postDetailAPI';
+import { BlogPostDetail } from '@/types/blogPost';
 
 interface ChatandMoreProps {
   commentRef?: React.RefObject<HTMLDivElement | null>;
+  postId?: string;
+  post?: BlogPostDetail;
 }
 
 const Container = styled.div`
@@ -25,7 +30,8 @@ const IconWrapper = styled.div`
   cursor: pointer;
 `;
 
-const ChatandMore = ({ commentRef }: ChatandMoreProps) => {
+const ChatandMore = ({ commentRef, postId, post }: ChatandMoreProps) => {
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const [isModalOpen, setModalOpen] = useState(false);
   const { isOpen, toggleDropdown, closeDropdown } = useDropdown();
   const { showToast } = useToast();
@@ -34,20 +40,56 @@ const ChatandMore = ({ commentRef }: ChatandMoreProps) => {
   const handleDropdownSelect = (item: string) => {
     if (item === '삭제하기') {
       setModalOpen(true);
+    } else if (item === '수정하기') {
+      if (!post?.isOwner) {
+        showToast('게시글 수정 권한이 없습니다!', 'negative');
+        return;
+      }
+      if (postId) {
+        navigate(`/blog/editor/${postId}`, {
+          state: {
+            postId,
+            title: post?.title,
+            contents: post?.contents,
+          },
+        });
+      }
     }
     closeDropdown();
   };
 
-  const handleConfirmDelete = () => {
-    setModalOpen(false);
-    console.log('블로그 삭제됨');
-    showToast('삭제가 완료되었습니다!', 'positive');
-    navigate('/');
+  const handleConfirmDelete = async () => {
+    if (!postId) {
+      showToast('삭제할 게시글이 없습니다.', 'negative');
+      return;
+    }
+
+    try {
+      await deletePost(postId);
+      setModalOpen(false);
+      showToast('삭제가 완료되었습니다!', 'positive');
+      navigate('/');
+    } catch (error) {
+      console.error('삭제 실패:', error);
+      showToast('삭제에 실패했습니다. 다시 시도해주세요.', 'negative');
+    }
   };
 
   const scrollToComments = () => {
     commentRef?.current?.scrollIntoView({ behavior: 'smooth' });
   };
+
+  // 바깥 클릭 감지
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (isOpen && dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        closeDropdown();
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen, closeDropdown]);
 
   return (
     <>
@@ -61,6 +103,7 @@ const ChatandMore = ({ commentRef }: ChatandMoreProps) => {
       </Container>
       {isOpen && (
         <Dropdown
+          ref={dropdownRef}
           isOpen={isOpen}
           menuItems={['수정하기', '삭제하기']}
           onSelect={handleDropdownSelect}

--- a/서나영-Blog/src/components/layout/header/ChatandMore.tsx
+++ b/서나영-Blog/src/components/layout/header/ChatandMore.tsx
@@ -41,10 +41,6 @@ const ChatandMore = ({ commentRef, postId, post }: ChatandMoreProps) => {
     if (item === '삭제하기') {
       setModalOpen(true);
     } else if (item === '수정하기') {
-      if (!post?.isOwner) {
-        showToast('게시글 수정 권한이 없습니다!', 'negative');
-        return;
-      }
       if (postId) {
         navigate(`/blog/editor/${postId}`, {
           state: {
@@ -101,7 +97,7 @@ const ChatandMore = ({ commentRef, postId, post }: ChatandMoreProps) => {
           <MoreVert width={24} height={24} />
         </IconWrapper>
       </Container>
-      {isOpen && (
+      {post?.isOwner && isOpen && (
         <Dropdown
           ref={dropdownRef}
           isOpen={isOpen}

--- a/서나영-Blog/src/components/layout/header/DelandCreate.tsx
+++ b/서나영-Blog/src/components/layout/header/DelandCreate.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { useToast } from '@/components/ui/Toast';
 import Modal from '@/components/ui/Modal';
+import { createPost, updatePost } from '@/api/blog/postDetailAPI';
+import { Block } from '@/types/blogPost';
 
 type TextType = 'Delete' | 'Create';
 
@@ -22,12 +24,15 @@ const Text = styled.p<{ type: TextType }>`
 interface Props {
   title: string;
   content: string;
+  blocks: Block[];
+  postId?: string;
 }
 
-const DelandCreate = ({ title, content }: Props) => {
-  const [isModalOpen, setModalOpen] = useState(false);
+const DelandCreate = ({ title, content, blocks, postId }: Props) => {
   const navigate = useNavigate();
   const { showToast } = useToast();
+
+  const [isModalOpen, setModalOpen] = useState(false);
 
   const handleDeleteClick = () => {
     setModalOpen(true);
@@ -40,12 +45,35 @@ const DelandCreate = ({ title, content }: Props) => {
     navigate('/');
   };
 
-  const handleCreateClick = () => {
-    if (!title.trim() || !content.trim()) {
+  const handleCreateClick = async () => {
+    const hasValidContent = blocks.some(
+      (block) => block.type === 'IMAGE' || block.content.trim() !== '',
+    );
+
+    if (!title.trim() || !hasValidContent) {
       showToast('내용을 입력해주세요', 'negative');
-    } else {
-      showToast('저장되었습니다!', 'positive');
-      navigate('/');
+      return;
+    }
+
+    try {
+      const postContents = blocks.map((block, index) => ({
+        contentOrder: index + 1,
+        content: block.content,
+        contentType: block.type,
+      }));
+
+      if (postId) {
+        await updatePost(postId, { title, contents: postContents });
+        showToast('수정되었습니다!', 'positive');
+        navigate(`/blog/${postId}`);
+      } else {
+        await createPost(title, postContents);
+        showToast('저장되었습니다!', 'positive');
+        navigate('/');
+      }
+    } catch (err) {
+      console.error(err);
+      showToast('게시 실패. 다시 시도해주세요.', 'negative');
     }
   };
 

--- a/서나영-Blog/src/components/layout/header/Header.tsx
+++ b/서나영-Blog/src/components/layout/header/Header.tsx
@@ -7,6 +7,7 @@ import CancelandSave from '@/components/layout/header/CancelandSave';
 import Button from '@/components/ui/Button';
 import Sidebar from '@/components/layout/sidebar/Sidebar';
 import styled from 'styled-components';
+import { BlogPostDetail } from '@/types/blogPost';
 
 type HeaderType = 'DelandCreate' | 'ChatandMore' | 'CreateLog' | 'Edit' | 'CancelandSave' | 'None';
 
@@ -16,7 +17,10 @@ interface HeaderProps {
   navigateEditor?: string;
   title?: string;
   content?: string;
+  blocks?: { content: string; type: 'TEXT' | 'IMAGE' }[];
   commentRef?: React.RefObject<HTMLDivElement | null>;
+  postId?: string;
+  post?: BlogPostDetail;
 }
 
 const HeaderContainer = styled.div`
@@ -67,7 +71,10 @@ const getRightComponent = (
   navigateEditor?: ReturnType<typeof useNavigate>,
   title?: string,
   content?: string,
+  blocks?: { content: string; type: 'TEXT' | 'IMAGE' }[],
   commentRef?: React.RefObject<HTMLDivElement | null>,
+  postId?: string,
+  post?: BlogPostDetail,
 ) => {
   switch (type) {
     case 'CreateLog':
@@ -82,9 +89,16 @@ const getRightComponent = (
         </Button>
       );
     case 'DelandCreate':
-      return <DelandCreate title={title ?? ''} content={content ?? ''} />;
+      return (
+        <DelandCreate
+          title={title ?? ''}
+          content={content ?? ''}
+          blocks={blocks ?? []}
+          postId={postId}
+        />
+      );
     case 'ChatandMore':
-      return <ChatandMore commentRef={commentRef} />;
+      return <ChatandMore commentRef={commentRef} postId={postId} post={post} />;
     case 'CancelandSave':
       return <CancelandSave />;
     case 'Edit':
@@ -100,7 +114,16 @@ const getRightComponent = (
   }
 };
 
-const Header = ({ type, onEditClick, title, content, commentRef }: HeaderProps) => {
+const Header = ({
+  type,
+  onEditClick,
+  title,
+  content,
+  blocks,
+  commentRef,
+  postId,
+  post,
+}: HeaderProps) => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const navigate = useNavigate();
 
@@ -123,7 +146,17 @@ const Header = ({ type, onEditClick, title, content, commentRef }: HeaderProps) 
           />
         </HeaderLeftSection>
         <HeaderRightSection>
-          {getRightComponent(type, onEditClick, navigate, title, content, commentRef)}
+          {getRightComponent(
+            type,
+            onEditClick,
+            navigate,
+            title,
+            content,
+            blocks,
+            commentRef,
+            postId,
+            post,
+          )}
         </HeaderRightSection>
       </HeaderContainer>
 

--- a/서나영-Blog/src/components/signup/ProfileUpload.tsx
+++ b/서나영-Blog/src/components/signup/ProfileUpload.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Profile, AddPhoto } from '@/assets';
-import { getPresignedUrl, uploadImage } from '@/api/ImageAPI';
+import { getPresignedUrl, uploadImage } from '@/api/image/ImageAPI';
 
 const ProfileContainer = styled.div`
   display: flex;

--- a/서나영-Blog/src/components/ui/Dropdown.tsx
+++ b/서나영-Blog/src/components/ui/Dropdown.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import styled from 'styled-components';
 
 interface DropdownProps {
@@ -37,20 +38,22 @@ const MenuItem = styled.div<{ danger?: boolean }>`
   }
 `;
 
-const Dropdown = ({ menuItems, isOpen, onSelect }: DropdownProps) => {
-  if (!isOpen) return null;
+const Dropdown = forwardRef<HTMLDivElement, DropdownProps>(
+  ({ menuItems, isOpen, onSelect }, ref) => {
+    if (!isOpen) return null;
 
-  return (
-    <DropdownWrapper>
-      <DropdownMenu>
-        {menuItems.map((item, index) => (
-          <MenuItem key={index} danger={item === '삭제하기'} onClick={() => onSelect?.(item)}>
-            {item}
-          </MenuItem>
-        ))}
-      </DropdownMenu>
-    </DropdownWrapper>
-  );
-};
+    return (
+      <DropdownWrapper ref={ref}>
+        <DropdownMenu>
+          {menuItems.map((item, index) => (
+            <MenuItem key={index} danger={item === '삭제하기'} onClick={() => onSelect?.(item)}>
+              {item}
+            </MenuItem>
+          ))}
+        </DropdownMenu>
+      </DropdownWrapper>
+    );
+  },
+);
 
 export default Dropdown;

--- a/서나영-Blog/src/pages/BlogDetail.tsx
+++ b/서나영-Blog/src/pages/BlogDetail.tsx
@@ -1,16 +1,31 @@
-import { useRef } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import Header from '@/components/layout/header/Header';
 import BlogTitle from '@/components/blog/blogDetail/BlogTitle';
-import { mockPosts } from '@/mocks/mockPosts';
 import BlogContent from '@/components/blog/blogDetail/BlogContent';
 import CommentList from '@/components/blog/blogDetail/comment/CommentList';
 import InfoFooter from '@/components/blog/blogDetail/InfoFooter';
+import { getPostDetail } from '@/api/blog/postDetailAPI';
+import { BlogPostDetail } from '@/types/blogPost';
 
 const BlogDetail = () => {
   const { postId } = useParams();
-  const post = mockPosts.find((p) => p.postId === postId);
+  const [post, setPost] = useState<BlogPostDetail | null>(null);
   const commentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const fetchPost = async () => {
+      try {
+        if (!postId) return;
+        const data = await getPostDetail(postId);
+        setPost(data);
+      } catch (error) {
+        console.error('게시글을 불러오지 못했습니다.', error);
+      }
+    };
+
+    fetchPost();
+  }, [postId]);
 
   if (!post) {
     return <div>해당 포스트를 찾을 수 없습니다.</div>;
@@ -18,7 +33,7 @@ const BlogDetail = () => {
 
   return (
     <div>
-      <Header type='ChatandMore' commentRef={commentRef} />
+      <Header type='ChatandMore' commentRef={commentRef} postId={postId} post={post} />
       <BlogTitle post={post} />
       <BlogContent contents={post.contents} />
       <div ref={commentRef}>

--- a/서나영-Blog/src/pages/BlogEditor.tsx
+++ b/서나영-Blog/src/pages/BlogEditor.tsx
@@ -1,9 +1,12 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import ContentEditor from '@/components/editor/ContentEditor';
 import ImageUpload from '@/components/editor/ImageUpload';
 import Header from '@/components/layout/header/Header';
 import TitleField from '@/components/editor/TitleField';
+import { getPresignedUrl, uploadImage } from '@/api/image/ImageAPI';
+import { Block } from '@/types/blogPost';
 
 const BlogEditorContainer = styled.div`
   overflow-x: hidden;
@@ -13,22 +16,74 @@ const BlogEditorContainer = styled.div`
   padding-bottom: 70px;
 `;
 
+interface LocationState {
+  postId?: string;
+  title?: string;
+  contents?: {
+    contentOrder: number;
+    content: string;
+    contentType: 'TEXT' | 'IMAGE';
+  }[];
+}
+
+const convertContentsToBlocks = (contents: LocationState['contents']): Block[] => {
+  if (!contents) return [];
+  return contents
+    .sort((a, b) => a.contentOrder - b.contentOrder)
+    .map((item) => ({
+      content: item.content,
+      type: item.contentType,
+    }));
+};
+
 const BlogEditor = () => {
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
+  const location = useLocation();
+  const state = location.state as LocationState | undefined;
+
+  const [postId] = useState(state?.postId || null);
+  const [title, setTitle] = useState(state?.title || '');
+  const [blocks, setBlocks] = useState<Block[]>(convertContentsToBlocks(state?.contents));
+
   const [imageToInsert, setImageToInsert] = useState<string | null>(null);
 
-  const handleAddImage = (imageUrl: string) => {
-    setImageToInsert(imageUrl);
-    setTimeout(() => setImageToInsert(null), 0);
+  // 최초 한 번만 초기 블록을 ContentEditor에 전달
+  const initialBlocksRef = useRef<Block[]>(convertContentsToBlocks(state?.contents));
+
+  const handleAddImage = async (file: File) => {
+    console.log('이미지 업로드 시작:', file);
+    try {
+      const presignedUrl = await getPresignedUrl(file.name);
+      const uploadedImageUrl = await uploadImage(presignedUrl, file);
+      setImageToInsert(uploadedImageUrl);
+      console.log('업로드된 URL:', uploadedImageUrl);
+    } catch (err) {
+      console.error('이미지 업로드 실패:', err);
+    }
   };
+
+  // content는 blocks에서 추출
+  const plainTextContent = blocks
+    .filter((block) => block.type === 'TEXT')
+    .map((block) => block.content)
+    .join('\n\n');
 
   return (
     <BlogEditorContainer>
-      <Header type='DelandCreate' title={title} content={content} />
+      <Header
+        type='DelandCreate'
+        title={title}
+        content={plainTextContent}
+        blocks={blocks}
+        postId={postId ?? undefined}
+      />
       <ImageUpload onAddImage={handleAddImage} />
       <TitleField value={title} onChange={(e) => setTitle(e.target.value)} />
-      <ContentEditor onChange={(value) => setContent(value)} />
+      <ContentEditor
+        onChange={(value, updatedBlocks) => setBlocks(updatedBlocks)}
+        imageToInsert={imageToInsert}
+        onImageInsertHandled={() => setImageToInsert(null)}
+        initialBlocks={initialBlocksRef.current}
+      />
     </BlogEditorContainer>
   );
 };

--- a/서나영-Blog/src/pages/BlogEditor.tsx
+++ b/서나영-Blog/src/pages/BlogEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import ContentEditor from '@/components/editor/ContentEditor';
@@ -62,10 +62,12 @@ const BlogEditor = () => {
   };
 
   // content는 blocks에서 추출
-  const plainTextContent = blocks
-    .filter((block) => block.type === 'TEXT')
-    .map((block) => block.content)
-    .join('\n\n');
+  const plainTextContent = useMemo(() => {
+    return blocks
+      .filter((block) => block.type === 'TEXT')
+      .map((block) => block.content)
+      .join('\n\n');
+  }, [blocks]);
 
   return (
     <BlogEditorContainer>

--- a/서나영-Blog/src/pages/Home.tsx
+++ b/서나영-Blog/src/pages/Home.tsx
@@ -1,28 +1,45 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import Header from '@/components/layout/header/Header';
 import Pagination from '@/components/pagination/Pagination';
 import PostList from '@/components/blog/PostList';
-import { mockPosts } from '@/mocks/mockPosts';
+import { getPostList, getPostListWithToken } from '@/api/blog/postAPI';
+import { BlogPost } from '@/types/blogPost';
+
+const pageSize = 5;
 
 const HomeContainer = styled.div`
   padding-top: 32px;
 `;
 
-const pageSize = 5;
-
 const Home = () => {
+  const location = useLocation();
   const [currentPage, setCurrentPage] = useState(1);
+  const [posts, setPosts] = useState<BlogPost[]>([]);
+  const [totalPages, setTotalPages] = useState(1);
 
-  const totalPages = Math.ceil(mockPosts.length / pageSize);
+  const fetchPosts = async () => {
+    try {
+      const token = localStorage.getItem('accessToken');
+      const fetcher = token ? getPostListWithToken : getPostList;
+      const data = await fetcher(currentPage, pageSize);
 
-  const startIdx = (currentPage - 1) * pageSize;
-  const currentPosts = mockPosts.slice(startIdx, startIdx + pageSize);
+      setPosts(data);
+      setTotalPages(Math.ceil(data.length / pageSize) || 1);
+    } catch (error) {
+      console.error('게시글 목록을 불러오지 못했습니다.', error);
+    }
+  };
+
+  useEffect(() => {
+    fetchPosts();
+  }, [currentPage, location.state?.refresh]);
 
   return (
     <HomeContainer>
       <Header type='CreateLog' />
-      <PostList posts={currentPosts} />
+      <PostList posts={posts} />
       <Pagination
         currentPage={currentPage}
         totalPages={totalPages}

--- a/서나영-Blog/src/types/blogPost.ts
+++ b/서나영-Blog/src/types/blogPost.ts
@@ -1,18 +1,34 @@
-export interface BlogPost {
-  postId: string;
-  title: string;
-  contents: BlogPostContent[];
-  comments: BlogComment[];
-  nickName: string;
-  createdAt: string;
-  profileUrl: string;
-  isOwner: boolean;
-}
-
 export interface BlogPostContent {
   contentOrder: number;
   content: string;
   contentType: 'TEXT' | 'IMAGE';
+}
+export interface BlogPost {
+  postId: string;
+  title: string;
+  contents: BlogPostContent[];
+  isOwner: boolean;
+  commentCount?: number;
+}
+
+export interface BlogPostDetail {
+  postId: string;
+  title: string;
+  contents: {
+    contentOrder: number;
+    content: string;
+    contentType: 'TEXT' | 'IMAGE';
+  }[];
+  isOwner: boolean;
+  comments: {
+    commentId: number;
+    content: string;
+    nickName: string;
+    isOwner: boolean;
+  }[];
+  nickName: string;
+  profileUrl: string;
+  createdAt: string;
 }
 
 export interface BlogComment {
@@ -20,4 +36,9 @@ export interface BlogComment {
   content: string;
   nickName: string;
   isOwner: boolean;
+}
+
+export interface Block {
+  content: string;
+  type: 'TEXT' | 'IMAGE';
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 게시글 리스트 조회 기능 구현
- 게시글 CRUD 기능 구현

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

- 메인 홈에서 게시글 리스트 조회 시 '/post/all', '/post/all/token'으로 get 요청을 받아올 때, 게시물 작성 날짜(`createdAt`), 게시글 작성자 정보(`profileUrl`, `nickName`) 값을 받아올 수 없어서 우선은 임시값으로만 구현해두었습니다. 혹시 다른 가져올 수 있는 방법이 있을까요..?🥺
![image](https://github.com/user-attachments/assets/f838c3d7-f3a0-48d2-b138-64933e98283f)

- 메인 홈에서 '/post/all', '/post/all/token'로 게시글 리스트를 불러올 때, 모든 게시글이 불러와지지 않는 이슈가 있습니다! 이 때문에 페이지네이션 부분도 구현이 어려운 상황인데, 혹시 total post 수를 프론트 쪽에서 알 수 있는 방법이 있을지 궁금합니다..

- 블로그 상세 페이지에서 게시글 수정 가능 여부를 `isOwner` 값으로 구현하려고 했으나, 게시글 작성자와 로그인 회원이 동일함에도 `isOwner`가 `false`로 반환되고 있어 구현이 어려운 상태입니다.. 
(게시글 수정 기능 자체는 게시글 작성자와 로그인 유저가 동일할 때 잘 작동하는 것은 확인했으나, 지금 상태로는 하단 코드처럼 수정 권한 여부를 처리하기가 어려울 것 같습니다,,ㅜ.ㅜ)
![image](https://github.com/user-attachments/assets/6d9556a0-46eb-45ce-91ed-d523ecf39381)
![image](https://github.com/user-attachments/assets/75c915df-4514-4119-8b4d-b3eed425298b)

<br>

## 3. 관련 스크린샷을 첨부해주세요.
- 메인 홈 
![image](https://github.com/user-attachments/assets/2f8ab62f-af18-4720-bbf3-89ff16bfa9b5)

- 게시글 상세 페이지
![image](https://github.com/user-attachments/assets/f5e3633f-1e2f-4f81-acff-9936470b4385)

<br>

## 4. 완료 사항

1. 게시글 리스트 조회 api 연결
2. 게시글 CRUD 기능 구현 및 api 연결 

<br>

## 5. 추가 사항

closed #43 

<br>